### PR TITLE
Use Fira Sans

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/system76/pop-plymouth-theme
 
 Package: plymouth-theme-pop-basic
 Architecture: all
-Depends: ${misc:Depends}, plymouth, plymouth-label, plymouth-themes
+Depends: ${misc:Depends}, plymouth, plymouth-label, plymouth-themes, pop-fonts
 Provides: plymouth-theme
 Breaks: pop-default-settings (<< 2)
 Replaces: pop-default-settings (<< 2)

--- a/debian/plymouth-theme-pop-basic.install
+++ b/debian/plymouth-theme-pop-basic.install
@@ -1,1 +1,2 @@
 usr/share/plymouth/themes/pop-basic/
+usr/share/initramfs-tools/hooks/plymouth-pop

--- a/usr/share/initramfs-tools/hooks/plymouth-pop
+++ b/usr/share/initramfs-tools/hooks/plymouth-pop
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Based on part of the behavior from Ubuntu's /usr/share/initramfs-tools/hooks/plymouth
+
+set -e
+
+mkdir -p "${DESTDIR}/usr/share/fonts/truetype/fira"
+cp -a /usr/share/fonts/opentype/fira/FiraSans-Regular.otf "${DESTDIR}/usr/share/fonts/fira"
+fc-cache -s -y "${DESTDIR}" > /dev/null 2>&1

--- a/usr/share/plymouth/themes/pop-basic/pop-basic.script
+++ b/usr/share/plymouth/themes/pop-basic/pop-basic.script
@@ -177,7 +177,7 @@ fun display_message_callback (text) {
       return;
   }
 
-  text_image = Image.Text(text, 1, 1, 1);
+  text_image = Image.Text(text, 1, 1, 1, 1, "Fira Sans, Regular 11");
   text_image = text_image.Scale(
     scale(text_image.GetWidth()),
     scale(text_image.GetHeight())


### PR DESCRIPTION
I had to carefully scrutinize the shapes of each character to convince myself that it is now using the correct font. So perhaps it's not that important, but it apparently works.

Fixes https://github.com/pop-os/plymouth-theme/issues/11.